### PR TITLE
Fix regex to allow matches ending in `\r`

### DIFF
--- a/src/fileUtils.ts
+++ b/src/fileUtils.ts
@@ -92,7 +92,7 @@ function parseTasksFromContent(content: string): Task[] {
 
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
-        const match = /^[-*]\s*\[([ x~!])\]\s*(.+)$/i.exec(line);
+        const match = /^[-*]\s*\[([ x~!])\]\s*(.+)$/im.exec(line);
 
         if (match) {
             const marker = match[1].toLowerCase();


### PR DESCRIPTION
Current regex does not match any task ending with `\r` and hence shows 0 tasks pending even if there are tasks in PRD.md.

This commit fixes that.